### PR TITLE
Arbitrary code execution vulnerability

### DIFF
--- a/src/Controller/EsiController.php
+++ b/src/Controller/EsiController.php
@@ -9,6 +9,7 @@ class EsiController extends ControllerBase
 {
     public function returnEsiBlockContent(Request $request)
     {
+        // @todo validate $request->get('callback') and $request->get('args'), using private key + salt.
         $build = [
             'esiBlockContent' => [
                 '#lazy_builder' => [


### PR DESCRIPTION
```
                '#lazy_builder' => [
                    $request->get('callback'),
                    $request->get('args'),
                ]
```

means arbitrary code could be executed. For example `$request->get('callback') === 'unlink'` and `$request->get('args') = ['~/.ssh/*']`.